### PR TITLE
Extend rxm and coll providers to be used with offload provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ config.log
 config.lt
 config.status
 configure
+configure~
 libtool
 
 libfabric.spec

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -128,6 +128,11 @@ pipeline {
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
                   git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+
+                  echo "Copy log dirs."
+                  python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
+                  echo "Copy log dirs completed."
+                  echo "-----------------------------------------------------"
                   python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='daos'
                   python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests
                 )
@@ -655,6 +660,20 @@ pipeline {
         }
       }
     }
+    stage ('Summary-daos') {
+      agent {node {label 'daos'}}
+      when { equals expected: 1, actual: DO_RUN }
+      steps {
+        withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin/:$PYTHONPATH']) {
+          sh """
+            env
+            (
+              python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py --summary_item=daos
+            )
+          """
+        }
+      }
+    }
   }
 
   post {
@@ -705,6 +724,7 @@ pipeline {
     success {
       node ('daos') {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
+          sh "python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/summary.py -v --summary_item=daos"
           dir ("${env.DAOS_CLUSTER_HOME}/avocado") {
             deleteDir()
           }

--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -127,7 +127,8 @@ pipeline {
                   else
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
-                  git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+                  
+                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
 
                   echo "Copy log dirs."
                   python3.7 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
@@ -157,7 +158,7 @@ pipeline {
                   else
                     rm -rf ${env.WORKSPACE}/py_scripts && mkdir ${env.WORKSPACE}/py_scripts
                   fi
-                  git clone ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
+                  git clone --branch ${TARGET} ${env.UPSTREAM} ${env.WORKSPACE}/py_scripts
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=logdir
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=libfabric --build_cluster='dsa'
                   python3.9 ${env.WORKSPACE}/${SCRIPT_LOCATION}/build.py --build_item=fabtests

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -929,6 +929,7 @@ class DaosCartTest(Test):
             print(test)
             command = self.cmd + self.options(test)
             outputcmd = shlex.split(command)
-            common.run_command(outputcmd)
+            common.run_command(outputcmd, self.ci_logdir_path,
+                               self.run_test, self.ofi_build_mode)
             print("--------------------TEST COMPLETED----------------------")
         os.chdir(curdir)

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -170,6 +170,7 @@ nobase_dist_config_DATA = \
 	pytest/efa/test_rnr.py \
 	pytest/efa/test_efa_info.py \
 	pytest/efa/test_efa_protocol_selection.py \
+	pytest/efa/test_efa_device_selection.py \
 	pytest/efa/test_runt.py \
 	pytest/efa/test_fork_support.py \
 	pytest/efa/test_mr.py \

--- a/fabtests/README.md
+++ b/fabtests/README.md
@@ -17,7 +17,7 @@ produce unexpected results.
 ## Building fabtests
 
 Distribution tarballs are available from the Github
-[releases](https://github.com/ofiwg/fabtests/releases) tab.
+[releases](https://github.com/ofiwg/libfabric/releases) tab.
 
 If you are building Fabtests from a developer Git clone, you must
 first run the `autogen.sh` script. This will invoke the GNU Autotools

--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -1,0 +1,39 @@
+import pytest
+
+
+# This test must be run in serial mode because it checks the hw counter
+@pytest.mark.serial
+@pytest.mark.functional
+def test_efa_device_selection(cmdline_args):
+    from efa.efa_common import efa_retrieve_hw_counter_value, get_efa_domain_names
+    from common import ClientServerTest
+
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("EFA device selection test requires 2 nodes")
+        return
+
+    efa_domain_names = get_efa_domain_names(cmdline_args.server_id)
+
+    for efa_domain_name in efa_domain_names:
+        if '-rdm' in efa_domain_name:
+            assert not('-dgrm') in efa_domain_name
+            fabtest_opts = "fi_rdm_pingpong"
+        elif '-dgrm' in efa_domain_name:
+            assert not('-rdm') in efa_domain_name
+            fabtest_opts = "fi_dgram_pingpong -k"
+
+        efa_device_name = efa_domain_name.split('-')[0]
+
+        server_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", efa_device_name)
+        client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", efa_device_name)
+
+        executable = "{} -d {}".format(fabtest_opts, efa_domain_name)
+        test = ClientServerTest(cmdline_args, executable, message_size="1000", timeout=300)
+        test.run()
+
+        server_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.server_id, "tx_bytes", efa_device_name)
+        client_tx_bytes_after_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes", efa_device_name)
+
+        # Verify EFA traffic
+        assert server_tx_bytes_before_test < server_tx_bytes_after_test
+        assert client_tx_bytes_before_test < client_tx_bytes_after_test

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -162,4 +162,8 @@ struct util_coll_operation {
 	uint64_t			flags;
 };
 
+int coll_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
+			struct fid_cq **cq_fid, ofi_cq_progress_func progress,
+			void *context);
+
 #endif // _OFI_COLL_H_

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -166,7 +166,6 @@ typedef struct fid *fid_t;
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
 #define FI_PEER_TRANSFER	(1ULL << 36)
-#define FI_PEER_DOMAIN		(1ULL << 38)
 #define FI_AV_USER_ID		(1ULL << 41)
 #define FI_PEER			(1ULL << 43)
 #define FI_XPU_TRIGGER		(1ULL << 44)

--- a/prov/coll/src/coll.h
+++ b/prov/coll/src/coll.h
@@ -60,6 +60,7 @@
 #include <ofi_hmem.h>
 #include <ofi_prov.h>
 #include <ofi_atomic.h>
+#include <ofi_coll.h>
 
 #define COLL_IOV_LIMIT 4
 #define COLL_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)

--- a/prov/coll/src/coll_cq.c
+++ b/prov/coll/src/coll_cq.c
@@ -86,7 +86,6 @@ int coll_cq_init(struct fid_domain *domain,
 	coll_domain = container_of(domain, struct coll_domain, util_domain.domain_fid.fid);
 	provider = coll_domain->util_domain.fabric->prov;
 
-
 	if (!attr || !(attr->flags & FI_PEER)) {
 		FI_WARN(provider, FI_LOG_CORE, "FI_PEER flag required\n");
                 return -EINVAL;
@@ -103,8 +102,7 @@ int coll_cq_init(struct fid_domain *domain,
 
 	cq->peer_cq = peer_context->cq;
 
-	ret = ofi_cq_init(provider, domain, attr, &cq->util_cq, &ofi_cq_progress,
-			  context);
+	ret = ofi_cq_init(provider, domain, attr, &cq->util_cq, progress, context);
 	if (ret)
 		goto err;
 

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -47,6 +47,7 @@ _efa_files = \
 	prov/efa/src/efa_user_info.c \
 	prov/efa/src/efa_prov_info.c \
 	prov/efa/src/efa_fork_support.c \
+	prov/efa/src/efa_tp_def.c \
 	prov/efa/src/rxr/rxr_prov.c	\
 	prov/efa/src/rxr/rxr_env.c	\
 	prov/efa/src/rxr/rxr_cq.c	\
@@ -77,6 +78,8 @@ _efa_headers = \
 	prov/efa/src/efa_prov_info.h \
 	prov/efa/src/efa_fork_support.h \
 	prov/efa/src/efa_cq.h \
+	prov/efa/src/efa_tp_def.h \
+	prov/efa/src/efa_tp.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_env.h \
 	prov/efa/src/rxr/rxr_cntr.h \

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -722,3 +722,21 @@ int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struc
 	return 0;
 }
 
+/*
+ * @brief Compare the domain name specified via hints and match it with the
+ *		  domain name in prov_info
+ *
+ * @param      info[in]        info object
+ * @param      hints[in]       hints from user's call to fi_getinfo()
+ *
+ * return      1 - If the names are different
+ *             0 - No difference, names match.
+ */
+int efa_prov_info_compare_domain_name(const struct fi_info *hints,
+                                      const struct fi_info *info)
+{
+       if (hints && hints->domain_attr && hints->domain_attr->name)
+               return strcmp(info->domain_attr->name, hints->domain_attr->name);
+
+       return 0;
+}

--- a/prov/efa/src/efa_prov_info.h
+++ b/prov/efa/src/efa_prov_info.h
@@ -45,4 +45,7 @@ int efa_prov_info_alloc_for_rxr(struct fi_info **prov_info_rxr,
 int efa_prov_info_compare_src_addr(const char *node, uint64_t flags, const struct fi_info *hints,
 				   const struct fi_info *fi);
 
+int efa_prov_info_compare_domain_name(const struct fi_info *hints,
+                                      const struct fi_info *info);
+
 #endif

--- a/prov/efa/src/efa_tp.h
+++ b/prov/efa/src/efa_tp.h
@@ -1,0 +1,51 @@
+#ifndef _EFA_TP_H_
+#define _EFA_TP_H_
+
+#include <config.h>
+
+#if HAVE_LTTNG
+#include "efa_tp_def.h"
+#include "rxr/rxr_op_entry.h"
+
+enum efa_tracing_ibv_post_type_t
+{
+	post_send,
+	post_recv
+} efa_tracing_ibv_post_type_t;
+
+typedef enum efa_tracing_ibv_post_type_t efa_tracing_ibv_post_type;
+
+static void efa_tracing_wr_id(const efa_tracing_ibv_post_type tp_name, const void *wr_id)
+{
+	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)wr_id;
+	struct rxr_op_entry *op_entry = (struct rxr_op_entry *)pkt_entry->x_entry;
+	if (!op_entry)
+		return;
+	switch (tp_name)
+	{
+	case post_send:
+		lttng_ust_tracepoint(EFA_TP_PROV, post_send,
+				     (size_t)wr_id,
+				     (size_t)op_entry,
+				     (size_t)op_entry->cq_entry.op_context);
+		break;
+	case post_recv:
+		lttng_ust_tracepoint(EFA_TP_PROV, post_recv,
+				     (size_t)wr_id,
+				     (size_t)op_entry,
+				     (size_t)op_entry->cq_entry.op_context);
+		break;
+	default:
+		assert(0);
+	}
+}
+#define efa_tracing(tp_name, ...) efa_tracing_wr_id(tp_name, __VA_ARGS__);
+
+#else
+#define efa_tracing(tp_name, ...) \
+	while (0)                 \
+	{                         \
+	}
+#endif
+
+#endif // _EFA_TP_H_

--- a/prov/efa/src/efa_tp_def.c
+++ b/prov/efa/src/efa_tp_def.c
@@ -1,0 +1,10 @@
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include <config.h>
+
+#if HAVE_LTTNG
+
+#include "efa_tp_def.h"
+
+#endif

--- a/prov/efa/src/efa_tp_def.h
+++ b/prov/efa/src/efa_tp_def.h
@@ -1,0 +1,50 @@
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER EFA_TP_PROV
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "efa_tp_def.h"
+
+#if !defined(_EFA_TP_DEF_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _EFA_TP_DEF_H
+
+#include <lttng/tracepoint.h>
+
+#define EFA_TP_PROV efa
+
+#define X_PKT_ARGS \
+	size_t, wr_id, \
+	size_t, rxr_op_entry, \
+	size_t, context
+
+#define X_PKT_FIELDS \
+	lttng_ust_field_integer_hex(size_t, wr_id, wr_id) \
+	lttng_ust_field_integer_hex(size_t, rxr_op_entry, rxr_op_entry) \
+	lttng_ust_field_integer_hex(size_t, context, context)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_TP_PROV,
+	post_send,
+	LTTNG_UST_TP_ARGS(
+		X_PKT_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_PKT_FIELDS  
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, post_send, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_TP_PROV,
+	post_recv,
+	LTTNG_UST_TP_ARGS(
+		X_PKT_ARGS
+	),
+	LTTNG_UST_TP_FIELDS(
+		X_PKT_FIELDS  
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_TP_PROV, post_recv, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+#endif // _EFA_TP_H
+
+#include <lttng/tracepoint-event.h>

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -218,6 +218,10 @@ int efa_user_info_get_dgram(uint32_t version, const char *node, const char *serv
 		if (ret)
 			continue;
 
+		ret = efa_prov_info_compare_domain_name(hints, prov_info_dgram);
+		if (ret)
+			continue;
+
 		EFA_INFO(FI_LOG_FABRIC, "found match for interface %s %s\n",
 			 node, prov_info_dgram->fabric_attr->name);
 		if (hints) {
@@ -443,6 +447,10 @@ int efa_user_info_get_rdm(uint32_t version, const char *node,
 	     prov_info_rxr;
 	     prov_info_rxr = prov_info_rxr->next) {
 		ret = efa_prov_info_compare_src_addr(node, flags, hints, prov_info_rxr);
+		if (ret)
+			continue;
+
+		ret = efa_prov_info_compare_domain_name(hints, prov_info_rxr);
 		if (ret)
 			continue;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -957,8 +957,8 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 	ssize_t ret;
 	struct rxr_ep *ep;
 	struct efa_domain *efa_domain;
-	char shm_ep_name[EFA_SHM_NAME_MAX];
-	size_t shm_ep_name_len;
+	char shm_ep_name[EFA_SHM_NAME_MAX], ep_addr_str[OFI_ADDRSTRLEN];
+	size_t shm_ep_name_len, ep_addr_strlen;
 
 	switch (command) {
 	case FI_ENABLE:
@@ -984,6 +984,11 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 		assert(ret != -FI_ETOOSMALL);
 		FI_DBG(&rxr_prov, FI_LOG_EP_CTRL, "core_addrlen = %ld\n",
 		       ep->core_addrlen);
+
+		ep_addr_strlen = sizeof(ep_addr_str);
+		rxr_ep_raw_addr_str(ep, ep_addr_str, &ep_addr_strlen);
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "libfabric %s efa endpoint created! address: %s\n",
+			fi_tostr("1", FI_TYPE_VERSION), ep_addr_str);
 
 		/* Enable shm provider endpoint & post recv buff.
 		 * Once core ep enabled, 18 bytes efa_addr (16 bytes raw + 2 bytes qpn) is set.

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -47,6 +47,8 @@
 #include "rxr_atomic.h"
 #include <infiniband/verbs.h>
 
+#include "rxr_tp.h"
+
 struct efa_ep_addr *rxr_ep_raw_addr(struct rxr_ep *ep)
 {
 	return (struct efa_ep_addr *)ep->core_addr;
@@ -1923,6 +1925,7 @@ static inline void rdm_ep_poll_ibv_cq_ex(struct rxr_ep *ep, size_t cqe_to_proces
 	should_end_poll = !err;
 
 	while (!err) {
+		rxr_tracing(poll_cq, (size_t) ep->ibv_cq_ex->wr_id);
 		if (ep->ibv_cq_ex->status) {
 			pkt_entry = (void *)(uintptr_t)ep->ibv_cq_ex->wr_id;
 			prov_errno = ibv_wc_read_vendor_err(ep->ibv_cq_ex);

--- a/prov/efa/src/rxr/rxr_tp_def.h
+++ b/prov/efa/src/rxr/rxr_tp_def.h
@@ -4,8 +4,8 @@
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
 #define LTTNG_UST_TRACEPOINT_INCLUDE "rxr/rxr_tp_def.h"
 
-#if !defined(_EFA_TP_DEF_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define _EFA_TP_DEF_H
+#if !defined(_EFA_RDM_TP_DEF_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define _EFA_RDM_TP_DEF_H
 
 #include <lttng/tracepoint.h>
 
@@ -188,6 +188,19 @@ LTTNG_UST_TRACEPOINT_EVENT(
 	)
 )
 LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, read_end, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	EFA_RDM_TP_PROV,
+	poll_cq,
+	LTTNG_UST_TP_ARGS(
+		size_t, wr_id
+	),
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer_hex(size_t, wr_id, wr_id)
+	)
+)
+LTTNG_UST_TRACEPOINT_LOGLEVEL(EFA_RDM_TP_PROV, poll_cq, LTTNG_UST_TRACEPOINT_LOGLEVEL_INFO)
+
 
 #endif // _EFA_TP_H
 

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -138,14 +138,16 @@ void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);
 
+union xnet_hdrs {
+	struct xnet_base_hdr	base_hdr;
+	struct xnet_cq_data_hdr cq_data_hdr;
+	struct xnet_tag_data_hdr tag_data_hdr;
+	struct xnet_tag_hdr	tag_hdr;
+	uint8_t			max_hdr[XNET_MAX_HDR];
+};
+
 struct xnet_active_rx {
-	union {
-		struct xnet_base_hdr	base_hdr;
-		struct xnet_cq_data_hdr cq_data_hdr;
-		struct xnet_tag_data_hdr tag_data_hdr;
-		struct xnet_tag_hdr	tag_hdr;
-		uint8_t			max_hdr[XNET_MAX_HDR];
-	} hdr;
+	union xnet_hdrs		hdr;
 	size_t			hdr_len;
 	size_t			hdr_done;
 	size_t			data_left;
@@ -364,13 +366,7 @@ static inline void xnet_signal_progress(struct xnet_progress *progress)
 
 struct xnet_xfer_entry {
 	struct slist_entry	entry;
-	union {
-		struct xnet_base_hdr	base_hdr;
-		struct xnet_cq_data_hdr cq_data_hdr;
-		struct xnet_tag_data_hdr tag_data_hdr;
-		struct xnet_tag_hdr	tag_hdr;
-		uint8_t		       	max_hdr[XNET_MAX_HDR + XNET_MAX_INJECT];
-	} hdr;
+	union xnet_hdrs		hdr;
 	void			*user_buf;
 	size_t			iov_cnt;
 	struct iovec		iov[XNET_IOV_LIMIT+1];

--- a/prov/net/src/xnet.h
+++ b/prov/net/src/xnet.h
@@ -202,7 +202,6 @@ struct xnet_ep {
 	int			rx_avail;
 	struct xnet_srx		*srx;
 
-	int			hit_cnt;
 	enum xnet_state		state;
 	struct util_peer_addr	*peer;
 	struct xnet_conn_handle *conn;

--- a/prov/net/src/xnet_cm.c
+++ b/prov/net/src/xnet_cm.c
@@ -128,7 +128,6 @@ int xnet_send_cm_msg(struct xnet_ep *ep)
 	if ((size_t) ret != len)
 		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
-	ep->hit_cnt++;
 	return FI_SUCCESS;
 }
 
@@ -153,7 +152,6 @@ void xnet_req_done(struct xnet_ep *ep)
 		goto disable;
 	}
 
-	ep->hit_cnt++;
 	if (xnet_trace_msg) {
 		ep->hdr_bswap = (ep->cm_msg->hdr.conn_data == 1) ?
 				xnet_hdr_trace : xnet_hdr_bswap_trace;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -844,6 +844,8 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct rxm_fabric *rxm_fabric;
 	struct fi_info *msg_info, *base_info;
 	struct fi_peer_domain_context peer_context;
+	struct fi_collective_attr attr;
+
 	int ret;
 
 	rxm_domain = calloc(1, sizeof(*rxm_domain));
@@ -893,6 +895,18 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 					 FI_PEER, &peer_context);
 			if (ret)
 				goto err5;
+
+			attr.op = FI_MIN;
+			attr.datatype = FI_INT8;
+			attr.datatype_attr.count =1;
+			attr.datatype_attr.size =1;
+			attr.mode = 0;
+			for (int i = FI_BARRIER; i < FI_GATHER; i++) {
+				ret = fi_query_collective(rxm_domain->offload_coll_domain,
+					i, &attr, 0);
+				if (FI_SUCCESS == ret)
+					rxm_domain->offload_coll_mask |= BIT(i);
+			}
 		}
 	}
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -319,6 +319,9 @@ static int rxm_query_collective(struct fid_domain *domain,
 
 	if (!rxm_domain->util_coll_domain)
 		return -FI_ENOSYS;
+	if (rxm_domain->offload_coll_domain)
+		return fi_query_collective(rxm_domain->offload_coll_domain,
+					coll, attr, flags);
 
 	return fi_query_collective(rxm_domain->util_coll_domain,
 				   coll, attr, flags);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -313,25 +313,25 @@ static int rxm_query_collective(struct fid_domain *domain,
 				uint64_t flags)
 {
 	struct rxm_domain *rxm_domain;
+	int ret;
 
 	rxm_domain = container_of(domain, struct rxm_domain,
 				  util_domain.domain_fid);
 
 	if (!rxm_domain->util_coll_domain)
 		return -FI_ENOSYS;
+
 	if (rxm_domain->offload_coll_domain)
-		return fi_query_collective(rxm_domain->offload_coll_domain,
-					coll, attr, flags);
+		ret = fi_query_collective(rxm_domain->offload_coll_domain,
+					  coll, attr, flags);
+	else
+		ret = -FI_ENOSYS;
+
+	if (FI_SUCCESS == ret || flags & OFI_OFFLOAD_PROV_ONLY)
+		return ret;
 
 	return fi_query_collective(rxm_domain->util_coll_domain,
 				   coll, attr, flags);
-
-	/*
-	 * TODO:
-	 * also check offload_coll_domain, we could use flags to indicate
-	 * whether we want to query all the collective providers, or offload
-	 * provider only.
-	 */
 }
 
 static struct fi_ops_domain rxm_domain_ops = {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1885,6 +1885,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 		peer_context.peer_ops = NULL;
 		if (rxm_domain->offload_coll_mask) {
+			rxm_fabric->offload_coll_info->mode |= FI_PEER_TRANSFER;
 			ret = fi_endpoint(rxm_domain->offload_coll_domain,
 					  rxm_fabric->offload_coll_info,
 					  &rxm_ep->offload_coll_ep,

--- a/prov/rxm/src/rxm_eq.c
+++ b/prov/rxm/src/rxm_eq.c
@@ -97,6 +97,13 @@ int rxm_eq_open(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 			goto err2;
 	}
 
+	if (rxm_fabric->offload_coll_fabric) {
+		ret = fi_eq_open(rxm_fabric->offload_coll_fabric, &peer_attr,
+				 &rxm_eq->offload_coll_eq, &peer_context);
+		if (ret)
+			goto err2;
+	}
+
 	rxm_eq->util_eq.eq_fid.fid.ops = &rxm_eq_fi_ops;
 	*eq_fid = &rxm_eq->util_eq.eq_fid;
 	return 0;

--- a/prov/rxm/src/rxm_fabric.c
+++ b/prov/rxm/src/rxm_fabric.c
@@ -157,8 +157,8 @@ int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		goto err3;
 	}
 
-	OFI_UNUSED(rxm_fabric_init_util_coll(rxm_fabric));
-	OFI_UNUSED(rxm_fabric_init_offload_coll(rxm_fabric));
+	(void) rxm_fabric_init_util_coll(rxm_fabric);
+	(void) rxm_fabric_init_offload_coll(rxm_fabric);
 
 	*fabric = &rxm_fabric->util_fabric.fabric_fid;
 	(*fabric)->fid.ops = &rxm_fabric_fi_ops;

--- a/prov/rxm/src/rxm_fabric.c
+++ b/prov/rxm/src/rxm_fabric.c
@@ -128,20 +128,20 @@ static int rxm_fabric_init_offload_coll(struct rxm_fabric *fabric)
 	 */
 	struct fi_info *hints, *offload_coll_info;
 	struct fid_fabric *offload_coll_fabric;
+	char *offload_coll_name;
 	int ret;
+
+	fi_param_get_str(NULL, "offload_coll_provider", &offload_coll_name);
+
+	if (!strlen(offload_coll_name)) {
+		return 0;
+	}
 
 	hints = fi_allocinfo();
 	if (!hints)
 		return -FI_ENOMEM;
 
-	hints->fabric_attr->prov_name = strdup(OFI_OFFLOAD_PREFIX "sharp"); // XXX to be fixed
-																		// provider is discovered
-																		// by feature 
-	if (!hints->fabric_attr->prov_name) {
-		fi_freeinfo(hints);
-		return -FI_ENOMEM;
-	}
-
+	hints->fabric_attr->prov_name = strdup(offload_coll_name);
 	hints->mode = FI_PEER_TRANSFER;
 	ret = fi_getinfo(OFI_VERSION_LATEST, NULL, NULL, OFI_OFFLOAD_PROV_ONLY,
 			 hints, &offload_coll_info);

--- a/prov/rxm/src/rxm_msg.c
+++ b/prov/rxm/src/rxm_msg.c
@@ -802,6 +802,10 @@ rxm_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		(data_len > rxm_ep->rxm_info->tx_attr->inject_size)) ||
 	       (data_len <= rxm_ep->rxm_info->tx_attr->inject_size));
 
+	iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
+	if (iface == FI_HMEM_ZE)
+		goto rndv_send;
+
 	if (data_len <= rxm_ep->eager_limit) {
 		ret = rxm_send_eager(rxm_ep, rxm_conn, iov, desc, count,
 				     context, data, flags, tag, op,
@@ -811,8 +815,7 @@ rxm_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				   context, data, flags, tag, op, data_len,
 				   rxm_ep_sar_calc_segs_cnt(rxm_ep, data_len));
 	} else {
-		iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
-
+rndv_send:
 		ret = rxm_alloc_rndv_buf(rxm_ep, rxm_conn, context,
 					 (uint8_t) count, iov, desc,
 					 data_len, data, flags, tag, op,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2017 Intel Corp., Inc.  All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2022 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -662,6 +663,8 @@ static void ofi_find_prov_libs(void)
 
 		if (ofi_has_util_prefix(prov->prov_name)) {
 			short_prov_name = prov->prov_name + strlen(OFI_UTIL_PREFIX);
+		} else if (ofi_has_offload_prefix(prov->prov_name)) {
+			short_prov_name = prov->prov_name + strlen(OFI_OFFLOAD_PREFIX);
 		} else {
 			short_prov_name = prov->prov_name;
 		}
@@ -833,6 +836,10 @@ void fi_ini(void)
 			"address is removed from the local AV.  "
 			"(default: false)");
 	fi_param_get_bool(NULL, "av_remove_cleanup", &ofi_av_remove_cleanup);
+
+	fi_param_define(NULL, "offload_coll_provider", FI_PARAM_STRING,
+			"The name of colective offload provider (default: empty - no provider)");
+
 
 	ofi_load_dl_prov();
 


### PR DESCRIPTION
Extend rxm and coll providers to work with collective offload providers:
- collective offload provider is given via FI_OFFLOAD_COLL_PROVIDER environment variable
- multinode tests do not fail if a provider does not explicitly support the requested collective operation
- collective offload provider's capabilities override the util coll provider's capabilities

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/libfabric/2)
<!-- Reviewable:end -->
